### PR TITLE
setup: install all `static/` files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,7 @@ setup(
         'sphinx_scality': [
             'theme.conf',
             '*.html',
-            'static/css/*.css',
-            'static/js/*.js',
-            'static/fonts/**/*.*',
-            'static/img/**/*.*',
+            'static/**/*',
         ]
     },
     entry_points={


### PR DESCRIPTION
Before, files like `*.js_t` and` *.css_t` were not copied when
installing the package. As such, when using it in a documentation
project, the resulting files would not exist, a browser would receive a
HTTP 404, and things would look... 'weird'.

Now, simply install `static/**/*`.