### PR TITLE
Template links in the footer

### DIFF
--- a/sphinx_scality/footer.html
+++ b/sphinx_scality/footer.html
@@ -6,9 +6,9 @@
     </a></div>
     <div class="links">
       Scality, Inc. All rights reserved. |
-      <a href="https://support.scality.com/">Support</a> |
-      <a href="#">Privacy Policy</a> |
-      <a href="#">Training</a>
+      {% for name, url in theme_footer_links %}
+      <a href="{{ url }}">{{ name }}</a> |
+      {% endfor %}
     </div>
     <div class="copyright">
       {%- if hasdoc('copyright') %}

--- a/sphinx_scality/theme.conf
+++ b/sphinx_scality/theme.conf
@@ -36,3 +36,4 @@ navigation_depth = 4
 titles_only = true
 
 social_links =
+footer_links =


### PR DESCRIPTION
Just as social links, the other links (support, privacy policy...) not involving icons have been templated.