### PR TITLE
Make back_arrow configurable

### DIFF
--- a/example/conf.py
+++ b/example/conf.py
@@ -126,10 +126,8 @@ html_theme_options = {
     'kblink': 'https://support.scality.com/hc/en-us',
     # If the pages are hosted on a website, configure the link to go back to
     'homelink': 'https://documentation.scality.com',
-    # This serves as an identifier of the project for which this doc is built
-    # It is used in the back-arrow link, computed as
-    # "<homelink>/<projectname>/<version>"
-    'projectname': 'RING',
+    # This is used for the back-arrow link
+    'parentlink': 'https://documentation.scality.com/RING/{}'.format(version),
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/sphinx_scality/header.html
+++ b/sphinx_scality/header.html
@@ -11,9 +11,9 @@
     <div class="quicksearch">
         {%- include "searchbox.html" %}
     </div>
-    {% if has_homelink %}
+    {% if theme_parentlink | default('') != '' %}
     <div class="back-arrow">
-        <a href="{{ theme_homelink }}/{{ theme_projectname }}/{{ version }}">
+        <a href="{{ theme_parentlink }}">
             <img class="back-arrow"
                  src="{{ pathto('_static/img/back-arrow.png', 1) }}"
                  alt="Website home"/>

--- a/sphinx_scality/theme.conf
+++ b/sphinx_scality/theme.conf
@@ -39,4 +39,4 @@ social_links =
 footer_links =
 kblink =
 homelink =
-projectname =
+parentlink =

--- a/sphinx_scality/theme.conf
+++ b/sphinx_scality/theme.conf
@@ -1,7 +1,6 @@
 [theme]
 inherit = classic
 stylesheet = css/theme.css
-pygments_style = sphinx
 
 [options]
 bgcolor = #FFFFFF


### PR DESCRIPTION
The back_arrow can be configured in conf.py, using the parent_link variable.
A project_variable, release or variable can be appended.

Ref: #22