### PR TITLE
Ensure the input part of commands don't overflow

### DIFF
--- a/example/book/example_commands/too-long.rst
+++ b/example/book/example_commands/too-long.rst
@@ -1,8 +1,10 @@
 .. command-block:: too-long
    :prompt: [root@long-hostname ~/scripts]#
 
-   ./lorem.sh
+   ./lorem.sh --title "Sooooooooooooooooooooooooooooomething reaaaaaaaaaaaaaaaaaaaaaaaaally loooooooooooooong"
    ---
+   # Sooooooooooooooooooooooooooooomething reaaaaaaaaaaaaaaaaaaaaaaaaally loooooooooooooong
+
    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
    Maecenas mattis eu nulla quis ultrices.
    Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/sphinx_scality/static/css/command-block.css_t
+++ b/sphinx_scality/static/css/command-block.css_t
@@ -22,6 +22,7 @@
 .command-block__input {
     flex-grow: 1;
     position: relative;
+    overflow-y: auto;
 }
 
 .command-block__output {


### PR DESCRIPTION
This was breaking in the `.command-block__command` area, which was
recently introduced to use `display: flex` instead of a simple `grid`
row (which simplifies width management for the prompt).

See: c0568fe

---

### Preview

![image](https://user-images.githubusercontent.com/45066113/132187642-c66e7a19-1286-4855-91af-07f27e7e242e.png)
