### PR TITLE
Fix the `copy-block` directive vertical scroll

### DIFF
--- a/sphinx_scality/static/css/copy.css_t
+++ b/sphinx_scality/static/css/copy.css_t
@@ -52,6 +52,7 @@
     font-size: .8rem;
     background: {{ theme_codecolor }};
     padding: .2rem;
+    margin-top: -.2rem;
     border-radius: .2rem;
     color: {{ theme_codebackgroundcolor }};
     display: none;


### PR DESCRIPTION
On mac screen (using chrome and firefox) when hovering the copy button the copy label was appearing a bit too down due to the padding which was making a vertical scroll appearing next to the copy button which change it's position making a bit more difficult to use.

Before : 

https://user-images.githubusercontent.com/75977494/132478682-7789236d-1fe1-46c7-90ff-3ee794c8b826.mov

After :

https://user-images.githubusercontent.com/75977494/132478734-308757c6-9128-4cfc-a606-6e7d0184846a.mov

