### PR TITLE
Fix variable

### DIFF
--- a/sphinx_scality/static/js/searchtools.js
+++ b/sphinx_scality/static/js/searchtools.js
@@ -313,9 +313,9 @@ var Search = {
         Search.title.text(_('Search Results'));
 
         if (DOCUMENTATION_OPTIONS.KBLINK != "") {
-          kbLink = `<a href="${DOCUMENTATION_OPTIONS.KBLINK}">Knowledge Base</a>`
+          kblink = `<a href="${DOCUMENTATION_OPTIONS.KBLINK}">Knowledge Base</a>`
           community = `<a href="https://support.scality.com/hc/en-us/community/topics">SOLVED Customer Community</a>`
-          extraHint = ` Try browsing the ${kbLink} or ask on ${community}. For urgent issues contact Scality Support.`
+          extraHint = ` Try browsing the ${kblink} or ask on ${community}. For urgent issues contact Scality Support.`
         } else {
           extraHint = ""
         }


### PR DESCRIPTION
`kblink` was not working properly on the documentation website. Indeed, sometimes the variable was named `kbLink`. Fixed consistency and corrected all occurrences into `kblink`.