### PR TITLE
docs: Improve the link for T&C by adding `pathto(file,1)` to better serve static PDF file

### DIFF
--- a/sphinx_scality/layout.html
+++ b/sphinx_scality/layout.html
@@ -136,7 +136,7 @@
       <div class="sidebar-termsandconditions">
         {%- if theme_termsandconditionspdf | default('') != '' %}
         <p class="rn-title">Terms and Conditions</p>
-        <a href="{{ theme_termsandconditionspdf }}">PDF</a>
+        <a href="{{ pathto(theme_termsandconditionspdf, 1) }}">PDF</a>
         {%- endif %}
       </div>
       {%- endblock %} {# sidebartermsandconditions #}


### PR DESCRIPTION
Recommended by the [Sphinx documentation](https://www.sphinx-doc.org/en/master/development/templating.html#pathto)